### PR TITLE
Ubuntu instructions and command readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,17 @@ There are two ways to run our extension, the difference between them is that by 
 **First Way (Recommended):**
 
 - Download Firefox ([🔥](https://www.mozilla.org/en-US/firefox/new/)).
-- Install Node.js and NPM if not already installed: [on Windows](https://phoenixnap.com/kb/install-node-js-npm-on-windows)
-- Clone the repo to your pc, by running the following command: `git clone https://github.com/norbit8/MoodleBooster.git`.
+- Install Node.js and NPM if not already installed: [on Windows](https://phoenixnap.com/kb/install-node-js-npm-on-windows), [on Ubuntu](https://www.liquidweb.com/kb/create-clone-repo-github-ubuntu-18-04/)
+- Clone the repo to your pc, by running the following command:  
+  `git clone https://github.com/norbit8/MoodleBooster.git`
 - Run `npm install` in the root directory of the project to install all dependencies.
 - From the root directory of the project run `npm run start` to start firefox with the web extension, then browse to moodle.
 
 **Second Way:**
 
 - Download Firefox ([🔥](https://www.mozilla.org/en-US/firefox/new/)).
-- Clone the repo to your pc, by running the following command: `git clone https://github.com/norbit8/MoodleBooster.git`.
+- Clone the repo to your pc, by running the following command:  
+  `git clone https://github.com/norbit8/MoodleBooster.git`
 - Go to Firefox and type: `about:debugging#/runtime/this-firefox` on the search bar.
 - Click on "Load Temporary Addon" and choose any file from the repo you've just cloned.
 


### PR DESCRIPTION
The end-of-sentence dot gets copied with the rest of the command, so it's better to remove it entirely. The command itself ended on the next line so I separated it entirely. As for Ubuntu - there are Firefox, npm and node.js on it, so we might as well add Linux instructions (can be tested by turning on Linux on Windows PC).