### PR TITLE
[FIX] Reset button doesn't work on chrome browser.

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -46,11 +46,8 @@ async function listenForClicks() {
 }
 
 async function handleReset() {
-    const confirm = window.confirm("Are you sure? reset is an irreversible action")
-    if (confirm) {
-        sendMessageToTabs("reset")
-        alert("Please refresh your browser tab to apply.")
-    }
+    await sendMessageToTabs("reset")
+    alert("Please refresh your browser tab to apply.")
 }
 
 /**


### PR DESCRIPTION
Fixed:

#135

The reset button wasn't working on chrome, the reason was that the line:

`window.confirm(...)` 

was causing problems, so I just removed that and reverted to the original solution. (IMO it's good enough)