### PR TITLE
[REFACTOR] Refactored courseRemover buttons to be inline of courses names

### DIFF
--- a/content_scripts/courseRemover.js
+++ b/content_scripts/courseRemover.js
@@ -15,41 +15,45 @@
      * Cleans the added button from addCourseRemovingOption() function
      */
     async function btnCleaner() {
-        btns = document.getElementsByClassName("btn-close");
-        while (btns.length !== 0) {
-            for (let i = 0; i < btns.length; ++i) {
-                btns[i].remove();
-            }
-            btns = document.getElementsByClassName("btn-close");
-        }
+        const buttons = document.querySelectorAll(".btn-close")
+        buttons.forEach(e => e.remove())
     }
 
+    function createHoverEffect(btn){
+        btn.addEventListener("mouseover", function() {
+            this.style.color = "#ff1c03";
+        });
+        btn.addEventListener("mouseout", function() {
+            this.style.color = "#961406";
+        });
+    }
+
+   async function clickListener(courses_list,courseIndex){
+        const link = courses_list[courseIndex].querySelector("a[href]").getAttribute("href")
+        const courseID = new URL(link).searchParams.get("id")
+        saveToStorage("RemovedCourses", courseID, false);
+        await btnCleaner();
+        courses_list[courseIndex].remove();
+        addCourseRemovingOption(); // refresh indices.
+    }
+    const BUTTON_STYLE = "background-color: Transparent;border: none;overflow: hidden;color: #961406 !important;font: caption; font-size: 20px !important; transform: translate(-15px, 27px);"
     /**
      * Adds buttons that removes courses from the courses pane
      */
     async function addCourseRemovingOption() {
         const courses_list = document.getElementsByClassName('type_course depth_3 contains_branch');
+        if(courses_list.length === 0){
+            return
+        }
         for (let courseIndex = 0; courseIndex < courses_list.length - 1; ++courseIndex) {
             let btn = document.createElement("button");
             btn.type = "button";
             btn.id = "bruh" + courseIndex;
             btn.className = "btn-close";
-            btn.style = "background-color: Transparent;border: none;overflow: hidden;color: #961406 !important;font: caption; font-size: 20px !important;"
+            btn.style = BUTTON_STYLE
             btn.innerHTML = "✖";
-            btn.addEventListener('click', async function () {
-                const link = courses_list[courseIndex].querySelector("a[href]").getAttribute("href")
-                const courseID = new URL(link).searchParams.get("id")
-                saveToStorage("RemovedCourses", courseID, false);
-                await btnCleaner();
-                courses_list[courseIndex].remove();
-                addCourseRemovingOption(); // refresh indecies.
-            });
-            btn.addEventListener("mouseover", function() {
-                this.style.color = "#ff1c03";
-              });
-            btn.addEventListener("mouseout", function() {
-            this.style.color = "#961406";
-            });
+            btn.addEventListener('click',() => clickListener(courses_list,courseIndex));
+            createHoverEffect(btn)
             courses_list[courseIndex].insertBefore(btn, courses_list[courseIndex].firstChild);
         }
     }


### PR DESCRIPTION
## What?

Refactored courseRemover buttons to be inline of courses names. (#141)

<img width="250" alt="Screen Shot 2021-06-26 at 12 02 36" src="https://user-images.githubusercontent.com/18491183/123508183-81f90e00-d676-11eb-9d0b-57844f68a3b1.png">

## Why?

It's more convenient for the user to use the buttons.